### PR TITLE
Add option to filter out extraneous dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,9 @@ var flatten = function(data, unversioned, json, options) {
     if (data[json.name + '@' + json.version]){ // prevent circular
         return;
     }
+    if (json.extraneous){ // filter out root devDependencies and manually installed packages
+        return;
+    }
 
     var moduleInfo = unversioned[json.name] || {licenses: UNKNOWN};
     var moduleId;


### PR DESCRIPTION
This is useful in case you have devDependencies and/or other packages
installed, but only want to check the dependencies of the root package.
