### PR TITLE
Actually output JSON when requested.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ exports.init = function(options, callback) {
 
 exports.print = function(sorted, format) {
     if (format === "json"){
-        console.log(sorted);
+        console.log(JSON.stringify(sorted));
     } else{
         console.log(treeify.asTree(sorted, true));
     }


### PR DESCRIPTION
Previously `-e json` output Node's "printable objects" format.