### PR TITLE
Upgrade read-installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "nopt-usage": "^0.1.0",
     "package-license": "~0.1.1",
     "pkginfo": "^0.3.0",
-    "read-installed": "~3.1.3",
+    "read-installed": "~4.0.3",
     "treeify": "~1.0.1",
     "underscore": "~1.4.4"
   },


### PR DESCRIPTION
`read-installed@3.1.5` depends on an old version of `graceful-fs` that is deprecated and will fail in node 7. This PR fixes that.

> npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.

Update: It will be removed in node 7, not 6.